### PR TITLE
Add stop task to manageiq and modify start

### DIFF
--- a/projects/manageiq.py
+++ b/projects/manageiq.py
@@ -79,7 +79,20 @@ def deploy():
 
     enable_tcp_ports([3000])
 
+
+@task
+def start_rails():
+    with cd('manageiq/vmdb'):
+        run('bin/rails server')
+
+
 @task
 def start():
     with cd('manageiq/vmdb'):
-        run('bin/rails server')
+        run('bundle exec rake evm:start')
+
+
+@task
+def stop():
+    with cd('manageiq/vmdb'):
+        run('bundle exec rake evm:kill')


### PR DESCRIPTION
Changes:
- added a stop task to kill manageiq
- added a start task to properly start managiq
- renamed the old start task to start_rails, so that it would be used
  by people working only on the UI
